### PR TITLE
Integrate routing daemon in ipvlan l3mode

### DIFF
--- a/drivers/ipvlan/ipvlan.go
+++ b/drivers/ipvlan/ipvlan.go
@@ -59,6 +59,7 @@ type networkConfiguration struct {
 	DefaultGatewayIPv6 net.IP
 	HostIface          string
 	IpvlanMode         string
+	RoutingManager     string
 }
 
 type subnet struct {

--- a/drivers/ipvlan/ipvlan_opts.go
+++ b/drivers/ipvlan/ipvlan_opts.go
@@ -16,4 +16,6 @@ const (
 	modeOpt = "_mode"
 	// The default macvlan mode
 	defaultMacvlanMode = "l2"
+	// l3 mode routing manager
+	routingManagerOpt = "routingmanager"
 )

--- a/drivers/ipvlan/routing/gobgp/common.go
+++ b/drivers/ipvlan/routing/gobgp/common.go
@@ -1,0 +1,26 @@
+package gobgp
+
+import (
+	"net"
+)
+
+type RibCache struct {
+	BgpTable map[string]*RibLocal
+}
+
+// Unmarshalled BGP update binding for simplicity
+type RibLocal struct {
+	BgpPrefix    *net.IPNet
+	OriginatorIP net.IP
+	NextHop      net.IP
+	Age          int
+	Best         bool
+	IsWithdraw   bool
+	IsHostRoute  bool
+	IsLocal      bool
+	AsPath       string
+}
+
+type RibTest struct {
+	BgpTable map[string]*RibLocal
+}

--- a/drivers/ipvlan/routing/gobgp/del_routes.go
+++ b/drivers/ipvlan/routing/gobgp/del_routes.go
@@ -1,0 +1,124 @@
+package gobgp
+
+import (
+	"fmt"
+	log "github.com/Sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+	"net"
+)
+
+// Cleanup links with netlink syscalls with a scope of:
+// RT_SCOPE_LINK = 0xfd (253)
+// RT_SCOPE_UNIVERSE = 0x0 (0)
+func cleanExistingRoutes(ifaceStr string) error {
+	iface, err := netlink.LinkByName(ifaceStr)
+	ipvlanParentIface, err := netlink.LinkByName(ifaceStr)
+	if err != nil {
+		log.Errorf("Error occoured finding the linux link [ %s ] from netlink: %s", ipvlanParentIface.Attrs().Name, err)
+		return err
+	}
+	routes, err := netlink.RouteList(iface, netlink.FAMILY_V4)
+	if err != nil {
+		log.Errorf("Unable to retreive netlink routes: %s", err)
+		return err
+	}
+	ifaceIP, err := getIfaceIP(ifaceStr)
+	if err != nil {
+		log.Errorf("Unable to retreive a usable IP via ethernet interface: %s", ifaceStr)
+		return err
+	}
+	fmt.Printf("route len %d", len(routes))
+	for _, route := range routes {
+		if route.Dst == nil {
+			fmt.Printf("route Dst is nil!")
+			continue
+		}
+		fmt.Printf(route.Src.String())
+		if netOverlaps(ifaceIP, route.Dst) == true {
+			log.Warnf("Ignoring route [ %v ] as it is associated to the [ %s ] interface", ifaceIP, ifaceStr)
+		} else if route.Scope == 0x0 || route.Scope == 0xfd {
+			// Remove link and universal routes from the docker host ipvlan interface
+			log.Infof("Cleaning static route cache for the destination: [ %s ]", route.Dst)
+			err := delRoute(route, ipvlanParentIface)
+			if err != nil {
+				log.Errorf("Error deleting static route cache for Destination: [ %s ] and Nexthop [ %s ] Error: %s", route.Dst, route.Gw, err)
+			}
+		}
+	}
+	return nil
+}
+
+func verifyRoute(bgpRoute *net.IPNet) {
+	networks, err := netlink.RouteList(nil, netlink.FAMILY_V4)
+	if err != nil {
+		return
+	}
+	for _, network := range networks {
+		if network.Dst != nil && netOverlaps(bgpRoute, network.Dst) {
+			log.Errorf("The network [ %v ] learned via BGP conflicts with an existing route on this host [ %v ]", bgpRoute, network.Dst)
+			return
+		}
+	}
+	return
+}
+
+func netOverlaps(netX *net.IPNet, netY *net.IPNet) bool {
+	if firstIP, _ := networkRange(netX); netY.Contains(firstIP) {
+		return true
+	}
+	if firstIP, _ := networkRange(netY); netX.Contains(firstIP) {
+		return true
+	}
+	return false
+}
+
+func networkRange(network *net.IPNet) (net.IP, net.IP) {
+	var (
+		netIP   = network.IP.To4()
+		firstIP = netIP.Mask(network.Mask)
+		lastIP  = net.IPv4(0, 0, 0, 0).To4()
+	)
+
+	for i := 0; i < len(lastIP); i++ {
+		lastIP[i] = netIP[i] | ^network.Mask[i]
+	}
+	return firstIP, lastIP
+}
+
+func getIfaceIP(name string) (*net.IPNet, error) {
+	iface, err := netlink.LinkByName(name)
+	if err != nil {
+		return nil, err
+	}
+	addrs, err := netlink.AddrList(iface, netlink.FAMILY_V4)
+	if err != nil {
+		return nil, err
+	}
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("Interface %v has no IP addresses", name)
+	}
+	if len(addrs) > 1 {
+		log.Info("Interface %v has more than 1 IPv4 address. Default is %v\n", name, addrs[0].IP)
+	}
+	return addrs[0].IPNet, nil
+}
+
+// delRoute deletes any netlink route
+func delRoute(route netlink.Route, iface netlink.Link) error {
+	return netlink.RouteDel(&netlink.Route{
+		Scope:     route.Scope,
+		LinkIndex: iface.Attrs().Index,
+		Dst:       route.Dst,
+		Gw:        route.Gw,
+	})
+}
+
+// delRemoteRoute deletes a host-scoped route to a device.
+func delRemoteRoute(neighborNetwork *net.IPNet, nextHop net.IP, iface netlink.Link) error {
+	return netlink.RouteDel(&netlink.Route{
+		Scope:     netlink.SCOPE_UNIVERSE,
+		LinkIndex: iface.Attrs().Index,
+		Dst:       neighborNetwork,
+		Gw:        nextHop,
+	})
+}

--- a/drivers/ipvlan/routing/gobgp/gobgp_routingmanager.go
+++ b/drivers/ipvlan/routing/gobgp/gobgp_routingmanager.go
@@ -1,0 +1,309 @@
+package gobgp
+
+import (
+	"fmt"
+	"net"
+
+	log "github.com/Sirupsen/logrus"
+	api "github.com/osrg/gobgp/api"
+	"github.com/osrg/gobgp/packet"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"io"
+	"time"
+)
+
+type BgpRouteManager struct {
+	// Master interface for IPVlan and BGP peering source
+	ethIface      string
+	server        net.IP
+	bgpgrpcclient api.GobgpApiClient
+	learnedRoutes []RibLocal
+	ModPathCh     chan *api.Path
+}
+
+func NewBgpRouteManager(masterIface string, server net.IP) *BgpRouteManager {
+	b := &BgpRouteManager{
+		ethIface:  masterIface,
+		server:    server,
+		ModPathCh: make(chan *api.Path),
+	}
+	return b
+}
+
+func (b *BgpRouteManager) StartMonitoring() error {
+	err := cleanExistingRoutes(b.ethIface)
+	if err != nil {
+		log.Infof("Error cleaning old routes: %s", err)
+	}
+	bgpCache := &RibCache{
+		BgpTable: make(map[string]*RibLocal),
+	}
+	timeout := grpc.WithTimeout(time.Second)
+	conn, err := grpc.Dial("127.0.0.1:8080", timeout, grpc.WithBlock(), grpc.WithInsecure())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer conn.Close()
+	b.bgpgrpcclient = api.NewGobgpApiClient(conn)
+	RibCh := make(chan *api.Path)
+	go b.monitorBestPath(RibCh)
+
+	log.Info("Initialization complete, now monitoring BGP for new routes..")
+	for {
+		select {
+		case p := <-RibCh:
+			monitorUpdate, err := bgpCache.handleBgpRibMonitor(p)
+
+			if err != nil {
+				log.Errorf("error processing bgp update [ %s ]", err)
+			}
+			if monitorUpdate.IsLocal != true {
+				if p.IsWithdraw {
+					monitorUpdate.IsWithdraw = true
+					log.Infof("BGP update has [ withdrawn ] the IP prefix [ %s ]", monitorUpdate.BgpPrefix.String())
+					// If the bgp update contained a withdraw, remove the local netlink route for the remote endpoint
+					err = delNetlinkRoute(monitorUpdate.BgpPrefix, monitorUpdate.NextHop, b.ethIface)
+					if err != nil {
+						log.Errorf("Error removing learned bgp route [ %s ]", err)
+					}
+				} else {
+					monitorUpdate.IsWithdraw = false
+					b.learnedRoutes = append(b.learnedRoutes, *monitorUpdate)
+					log.Debugf("Learned routes: %v ", monitorUpdate)
+
+					err = addNetlinkRoute(monitorUpdate.BgpPrefix, monitorUpdate.NextHop, b.ethIface)
+					if err != nil {
+						log.Debugf("Add route results [ %s ]", err)
+					}
+
+					log.Infof("Updated the local prefix cache from the newly learned BGP update:")
+					for n, entry := range b.learnedRoutes {
+						log.Debugf("%d - %+v", n+1, entry)
+					}
+				}
+			}
+			log.Debugf("Verbose update details: %s", monitorUpdate)
+		case m := <-b.ModPathCh:
+			arg := &api.ModPathArguments{
+				Resource: api.Resource_GLOBAL,
+				Paths:    []*api.Path{m},
+			}
+			stream, err := b.bgpgrpcclient.ModPath(context.Background())
+			if err != nil {
+				return err
+			}
+
+			err = stream.Send(arg)
+			if err != nil {
+				return err
+			}
+			stream.CloseSend()
+
+			res, err := stream.CloseAndRecv()
+			if err != nil {
+				return err
+			}
+			if res.Code != api.Error_SUCCESS {
+				return fmt.Errorf("error: code: %d, msg: %s\n", res.Code, res.Msg)
+			}
+		}
+	}
+}
+
+func (b *BgpRouteManager) monitorBestPath(RibCh chan *api.Path) error {
+	timeout := grpc.WithTimeout(time.Second)
+	conn, err := grpc.Dial("127.0.0.1:8080", timeout, grpc.WithBlock(), grpc.WithInsecure())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer conn.Close()
+	client := api.NewGobgpApiClient(conn)
+
+	arg := &api.Arguments{
+		Resource: api.Resource_GLOBAL,
+		Rf:       uint32(bgp.RF_IPv4_UC),
+	}
+	err = func() error {
+		stream, err := client.GetRib(context.Background(), arg)
+		if err != nil {
+			return err
+		}
+		for {
+			dst, err := stream.Recv()
+			if err == io.EOF {
+				break
+			} else if err != nil {
+				return err
+			}
+			for _, p := range dst.Paths {
+				if p.Best {
+					RibCh <- p
+					break
+				}
+			}
+		}
+		return nil
+	}()
+
+	if err != nil {
+		return err
+	}
+	stream, err := client.MonitorBestChanged(context.Background(), arg)
+	if err != nil {
+		return err
+	}
+	for {
+		dst, err := stream.Recv()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+		RibCh <- dst.Paths[0]
+	}
+	return nil
+}
+
+// Advertise the local namespace IP prefixes to the bgp neighbors
+func (b *BgpRouteManager) AdvertizeNewRoute(localPrefix *net.IPNet) error {
+	log.Infof("Adding this hosts container network [ %s ] into the BGP domain", localPrefix)
+	path := &api.Path{
+		Pattrs:     make([][]byte, 0),
+		IsWithdraw: false,
+	}
+	localPrefixMask, _ := localPrefix.Mask.Size()
+	path.Nlri, _ = bgp.NewIPAddrPrefix(uint8(localPrefixMask), localPrefix.IP.String()).Serialize()
+	n, _ := bgp.NewPathAttributeNextHop("0.0.0.0").Serialize()
+	path.Pattrs = append(path.Pattrs, n)
+	origin, _ := bgp.NewPathAttributeOrigin(bgp.BGP_ORIGIN_ATTR_TYPE_IGP).Serialize()
+	path.Pattrs = append(path.Pattrs, origin)
+	b.ModPathCh <- path
+	return nil
+}
+func (b *BgpRouteManager) WithdrawRoute(localPrefix *net.IPNet) error {
+	log.Infof("Withdraw this hosts container network [ %s ] from the BGP domain", localPrefix)
+	path := &api.Path{
+		Pattrs:     make([][]byte, 0),
+		IsWithdraw: true,
+	}
+	localPrefixMask, _ := localPrefix.Mask.Size()
+	path.Nlri, _ = bgp.NewIPAddrPrefix(uint8(localPrefixMask), localPrefix.IP.String()).Serialize()
+	n, _ := bgp.NewPathAttributeNextHop("0.0.0.0").Serialize()
+	path.Pattrs = append(path.Pattrs, n)
+	origin, _ := bgp.NewPathAttributeOrigin(bgp.BGP_ORIGIN_ATTR_TYPE_IGP).Serialize()
+	path.Pattrs = append(path.Pattrs, origin)
+	b.ModPathCh <- path
+	return nil
+}
+func (cache *RibCache) handleBgpRibMonitor(routeMonitor *api.Path) (*RibLocal, error) {
+	ribLocal := &RibLocal{}
+	var nlri bgp.AddrPrefixInterface
+
+	if len(routeMonitor.Nlri) > 0 {
+		nlri = &bgp.IPAddrPrefix{}
+		err := nlri.DecodeFromBytes(routeMonitor.Nlri)
+		if err != nil {
+			log.Errorf("Error parsing the bgp update nlri")
+		}
+		bgpPrefix, err := ParseIPNet(nlri.String())
+		if err != nil {
+			log.Errorf("Error parsing the bgp update prefix")
+		}
+		ribLocal.BgpPrefix = bgpPrefix
+
+	}
+	log.Debugf("BGP update for prefix: [ %s ] ", nlri.String())
+	for _, attr := range routeMonitor.Pattrs {
+		p, err := bgp.GetPathAttribute(attr)
+		if err != nil {
+			log.Errorf("Error parsing the bgp update attr")
+		}
+		err = p.DecodeFromBytes(attr)
+		if err != nil {
+			log.Errorf("Error parsing the bgp update attr")
+		}
+		log.Debugf("Type: [ %d ] ,Value [ %s ]", p.GetType(), p.String())
+		switch p.GetType() {
+		case bgp.BGP_ATTR_TYPE_ORIGIN:
+			// 0 = iBGP; 1 = eBGP
+			if p.(*bgp.PathAttributeOrigin).Value != nil {
+				log.Debugf("Type Code: [ %d ] Origin: %g", bgp.BGP_ATTR_TYPE_ORIGIN, p.(*bgp.PathAttributeOrigin).String())
+			}
+		case bgp.BGP_ATTR_TYPE_AS_PATH:
+			if p.(*bgp.PathAttributeAsPath).Value != nil {
+				log.Debugf("Type Code: [ %d ] AS_Path: %s", bgp.BGP_ATTR_TYPE_AS_PATH, p.String())
+			}
+		case bgp.BGP_ATTR_TYPE_NEXT_HOP:
+			if p.(*bgp.PathAttributeNextHop).Value.String() != "" {
+				log.Debugf("Type Code: [ %d ] Nexthop: %s", bgp.BGP_ATTR_TYPE_NEXT_HOP, p.String())
+				n := p.(*bgp.PathAttributeNextHop)
+				ribLocal.NextHop = n.Value
+				if ribLocal.NextHop.String() == "0.0.0.0" {
+					ribLocal.IsLocal = true
+				}
+			}
+		case bgp.BGP_ATTR_TYPE_MULTI_EXIT_DISC:
+			if p.(*bgp.PathAttributeMultiExitDisc).Value >= 0 {
+				log.Debugf("Type Code: [ %d ] MED: %g", bgp.BGP_ATTR_TYPE_MULTI_EXIT_DISC, p.String())
+			}
+		case bgp.BGP_ATTR_TYPE_LOCAL_PREF:
+			if p.(*bgp.PathAttributeLocalPref).Value >= 0 {
+				log.Debugf("Type Code: [ %d ] Local Pref: %g", bgp.BGP_ATTR_TYPE_LOCAL_PREF, p.String())
+			}
+		case bgp.BGP_ATTR_TYPE_ORIGINATOR_ID:
+			if p.(*bgp.PathAttributeOriginatorId).Value != nil {
+				log.Debugf("Type Code: [ %d ] Originator IP: %s", bgp.BGP_ATTR_TYPE_ORIGINATOR_ID, p.String())
+				ribLocal.OriginatorIP = p.(*bgp.PathAttributeOriginatorId).Value
+				log.Debugf("Type Code: [ %d ] Originator IP: %s", bgp.BGP_ATTR_TYPE_ORIGINATOR_ID, ribLocal.OriginatorIP)
+			}
+		case bgp.BGP_ATTR_TYPE_CLUSTER_LIST:
+			if len(p.(*bgp.PathAttributeClusterList).Value) > 0 {
+				log.Debugf("Type Code: [ %d ] Cluster List: %s", bgp.BGP_ATTR_TYPE_CLUSTER_LIST, p.String())
+			}
+		case bgp.BGP_ATTR_TYPE_MP_REACH_NLRI:
+			if p.(*bgp.PathAttributeMpReachNLRI).Value != nil {
+				log.Debugf("Type Code: [ %d ] MP Reachable: %v", bgp.BGP_ATTR_TYPE_MP_REACH_NLRI, p.String())
+				mpreach := p.(*bgp.PathAttributeMpReachNLRI)
+				if len(mpreach.Value) != 1 {
+					log.Errorf("include only one route in mp_reach_nlri")
+				}
+				nlri = mpreach.Value[0]
+				ribLocal.NextHop = mpreach.Nexthop
+				if ribLocal.NextHop.String() == "0.0.0.0" {
+					ribLocal.IsLocal = true
+				}
+			}
+		case bgp.BGP_ATTR_TYPE_MP_UNREACH_NLRI:
+			if p.(*bgp.PathAttributeMpUnreachNLRI).Value != nil {
+				log.Debugf("Type Code: [ %d ]  MP Unreachable: %v", bgp.BGP_ATTR_TYPE_MP_UNREACH_NLRI, p.String())
+			}
+		case bgp.BGP_ATTR_TYPE_EXTENDED_COMMUNITIES:
+			if p.(*bgp.PathAttributeExtendedCommunities).Value != nil {
+				log.Debugf("Type Code: [ %d ] Extended Communities: %v", bgp.BGP_ATTR_TYPE_EXTENDED_COMMUNITIES, p.String())
+			}
+		default:
+			log.Errorf("Unknown BGP attribute code [ %d ]")
+		}
+	}
+	return ribLocal, nil
+
+}
+
+// return string representation of pluginConfig for debugging
+func (d *RibLocal) stringer() string {
+	str := fmt.Sprintf("Prefix:[ %s ], ", d.BgpPrefix.String())
+	str = str + fmt.Sprintf("OriginatingIP:[ %s ], ", d.OriginatorIP.String())
+	str = str + fmt.Sprintf("Nexthop:[ %s ], ", d.NextHop.String())
+	str = str + fmt.Sprintf("IsWithdrawn:[ %t ], ", d.IsWithdraw)
+	str = str + fmt.Sprintf("IsHostRoute:[ %t ]", d.IsHostRoute)
+	return str
+}
+
+func ParseIPNet(s string) (*net.IPNet, error) {
+	ip, ipNet, err := net.ParseCIDR(s)
+	if err != nil {
+		return nil, err
+	}
+	return &net.IPNet{IP: ip, Mask: ipNet.Mask}, nil
+}

--- a/drivers/ipvlan/routing/gobgp/routes.go
+++ b/drivers/ipvlan/routing/gobgp/routes.go
@@ -1,0 +1,68 @@
+package gobgp
+
+import (
+	"fmt"
+	"net"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+)
+
+// AddHostRoute adds a route to a device using netlink into the Linux default namespace.
+func addNetlinkRoute(neighborNetwork *net.IPNet, nextHop net.IP, netIface string) error {
+	iface, err := netlink.LinkByName(netIface)
+	if err != nil {
+		return err
+	}
+	log.Infof("Adding route learned via BGP for a remote endpoint with:")
+	log.Infof("IP Prefix: [ %s ] - Next Hop: [ %s ] - Source Interface: [ %s ]", neighborNetwork, nextHop, iface.Attrs().Name)
+	return netlink.RouteAdd(&netlink.Route{
+		Scope:     netlink.SCOPE_UNIVERSE,
+		LinkIndex: iface.Attrs().Index,
+		Dst:       neighborNetwork,
+		Gw:        nextHop,
+	})
+}
+
+// AddHostRoute adds a route to a device using netlink into the Linux default namespace.
+func delNetlinkRoute(neighborNetwork *net.IPNet, nextHop net.IP, netIface string) error {
+	iface, err := netlink.LinkByName(netIface)
+	if err != nil {
+		return err
+	}
+	log.Infof("IP Prefix: [ %s ] - Next Hop: [ %s ] - Source Interface: [ %s ]", neighborNetwork, nextHop, iface.Attrs().Name)
+	return netlink.RouteDel(&netlink.Route{
+		Scope:     netlink.SCOPE_UNIVERSE,
+		LinkIndex: iface.Attrs().Index,
+		Dst:       neighborNetwork,
+		Gw:        nextHop,
+	})
+}
+
+// Add a route to the global namespace using the default gateway to determine the iface
+func checkAddRoute(dest *net.IPNet, nh net.IP) error {
+	gwRoutes, err := netlink.RouteGet(nh)
+	if err != nil {
+		return fmt.Errorf("route for the next hop %s could not be found: %v", nh, err)
+	}
+	return netlink.RouteAdd(&netlink.Route{
+		Scope:     netlink.SCOPE_UNIVERSE,
+		LinkIndex: gwRoutes[0].LinkIndex,
+		Gw:        gwRoutes[0].Gw,
+		Dst:       dest,
+	})
+}
+
+// AddHostRoute adds a host-scoped route to a device.
+func addRoute(neighborNetwork *net.IPNet, nextHop net.IP, iface netlink.Link) error {
+	log.Debugf("Adding route in the default namespace for IPVlan L3 mode with the following:")
+	log.Debugf("IP Prefix: [ %s ] - Next Hop: [ %s ] - Source Interface: [ %s ]",
+		neighborNetwork, nextHop, iface.Attrs().Name)
+
+	return netlink.RouteAdd(&netlink.Route{
+		Scope:     netlink.SCOPE_UNIVERSE,
+		LinkIndex: iface.Attrs().Index,
+		Dst:       neighborNetwork,
+		Gw:        nextHop,
+	})
+}

--- a/drivers/ipvlan/routing/routing-interface.go
+++ b/drivers/ipvlan/routing/routing-interface.go
@@ -1,0 +1,48 @@
+package routingmanager
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/libnetwork/drivers/ipvlan/routing/gobgp"
+	"net"
+)
+
+var routemanager RoutingInterface
+
+type RoutingInterface interface {
+	StartMonitoring() error
+	AdvertizeNewRoute(localPrefix *net.IPNet) error
+	WithdrawRoute(localPrefix *net.IPNet) error
+}
+
+func InitRoutingManager(masterIface string, managermode string, serveraddr string) {
+	switch managermode {
+	case "gobgp":
+		log.Infof("Routing manager is %s", managermode)
+		routemanager = gobgp.NewBgpRouteManager(masterIface, net.ParseIP(serveraddr))
+	default:
+		log.Infof("Default Routing manager: Gobgp")
+		routemanager = gobgp.NewBgpRouteManager(masterIface, net.ParseIP(serveraddr))
+	}
+}
+
+func StartMonitoring() error {
+	error := routemanager.StartMonitoring()
+	if error != nil {
+		return error
+	}
+	return nil
+}
+func WithdrawRoute(localPrefix *net.IPNet) error {
+	error := routemanager.WithdrawRoute(localPrefix)
+	if error != nil {
+		return error
+	}
+	return nil
+}
+func AdvertizeNewRoute(localPrefix *net.IPNet) error {
+	error := routemanager.AdvertizeNewRoute(localPrefix)
+	if error != nil {
+		return error
+	}
+	return nil
+}


### PR DESCRIPTION
Automatically advertise route information for containers with GoBGP ( or other  routing daemon) in ipvlan l3 mode.
Almost same gopher-net/ipvlan-docker-plugin BGP Extention(https://github.com/gopher-net/ipvlan-docker-plugin/pull/11).

 - add routingmanager option
 - e.g. -o routingmanager=gobgp, communicate to Gobgp daemon with grcp
 - you need gobgp config file (AS number and neighbor list)

Signed-off-by: YujiOshima <yuji.oshima0x3fd@gmail.com>